### PR TITLE
Implement LeftPad in COBOL and add necessary files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,44 @@
 # cobol-leftpad
 LeftPad for your COBOL applications
+
+## Using LeftPad as a Library in COBOL Applications
+
+To use the LeftPad implementation in your COBOL application, follow these steps:
+
+1. Copy the `leftpad.cbl` and `leftpad.cpy` files into your project directory.
+2. In your COBOL program, include the `leftpad.cpy` copybook where you want to use the LeftPad function.
+
+Example:
+```cobol
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. Example.
+       ENVIRONMENT DIVISION.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       COPY 'leftpad.cpy'.
+       01  Result-String  PIC X(20).
+
+       PROCEDURE DIVISION.
+           CALL 'LeftPad' USING 'Hello', 20, ' ', Result-String
+           DISPLAY Result-String
+           STOP RUN.
+```
+
+## Compiling and Running the Example Program
+
+To compile and run the example program, follow these steps:
+
+1. Ensure you have a COBOL compiler installed on your system.
+2. Open a terminal and navigate to the directory containing the `example.cbl`, `leftpad.cbl`, and `leftpad.cpy` files.
+3. Compile the `leftpad.cbl` file:
+   ```sh
+   cobc -c leftpad.cbl
+   ```
+4. Compile the `example.cbl` file and link it with the `leftpad` object file:
+   ```sh
+   cobc -x example.cbl leftpad.o -o example
+   ```
+5. Run the compiled program:
+   ```sh
+   ./example
+   ```

--- a/example.cbl
+++ b/example.cbl
@@ -1,0 +1,12 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. Example.
+       ENVIRONMENT DIVISION.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       COPY 'leftpad.cpy'.
+       01  Result-String  PIC X(20).
+
+       PROCEDURE DIVISION.
+           CALL 'LeftPad' USING 'Hello', 20, ' ', Result-String
+           DISPLAY Result-String
+           STOP RUN.

--- a/examples/example.cbl
+++ b/examples/example.cbl
@@ -1,0 +1,12 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. Example.
+       ENVIRONMENT DIVISION.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       COPY 'leftpad.cpy'.
+       01  Result-String  PIC X(20).
+
+       PROCEDURE DIVISION.
+           CALL 'LeftPad' USING 'Hello', 20, ' ', Result-String
+           DISPLAY Result-String
+           STOP RUN.

--- a/leftpad.cbl
+++ b/leftpad.cbl
@@ -1,0 +1,22 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. LeftPad.
+       ENVIRONMENT DIVISION.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  Input-String      PIC X(100).
+       01  Padded-String     PIC X(100).
+       01  Pad-Character     PIC X.
+       01  Pad-Length        PIC 9(3).
+       01  Input-Length      PIC 9(3).
+       01  Pad-Count         PIC 9(3).
+       01  Index             PIC 9(3).
+
+       PROCEDURE DIVISION USING Input-String, Pad-Length, Pad-Character, Padded-String.
+           MOVE FUNCTION LENGTH(Trim(Input-String)) TO Input-Length
+           COMPUTE Pad-Count = Pad-Length - Input-Length
+           MOVE SPACES TO Padded-String
+           PERFORM VARYING Index FROM 1 BY 1 UNTIL Index > Pad-Count
+               MOVE Pad-Character TO Padded-String(Index:1)
+           END-PERFORM
+           STRING Input-String DELIMITED BY SIZE INTO Padded-String WITH POINTER Index
+           GOBACK.

--- a/leftpad.cpy
+++ b/leftpad.cpy
@@ -1,0 +1,17 @@
+       01  Input-String      PIC X(100).
+       01  Padded-String     PIC X(100).
+       01  Pad-Character     PIC X.
+       01  Pad-Length        PIC 9(3).
+       01  Input-Length      PIC 9(3).
+       01  Pad-Count         PIC 9(3).
+       01  Index             PIC 9(3).
+
+       PROCEDURE DIVISION USING Input-String, Pad-Length, Pad-Character, Padded-String.
+           MOVE FUNCTION LENGTH(Trim(Input-String)) TO Input-Length
+           COMPUTE Pad-Count = Pad-Length - Input-Length
+           MOVE SPACES TO Padded-String
+           PERFORM VARYING Index FROM 1 BY 1 UNTIL Index > Pad-Count
+               MOVE Pad-Character TO Padded-String(Index:1)
+           END-PERFORM
+           STRING Input-String DELIMITED BY SIZE INTO Padded-String WITH POINTER Index
+           GOBACK.

--- a/src/leftpad.cbl
+++ b/src/leftpad.cbl
@@ -1,0 +1,22 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. LeftPad.
+       ENVIRONMENT DIVISION.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  Input-String      PIC X(100).
+       01  Padded-String     PIC X(100).
+       01  Pad-Character     PIC X.
+       01  Pad-Length        PIC 9(3).
+       01  Input-Length      PIC 9(3).
+       01  Pad-Count         PIC 9(3).
+       01  Index             PIC 9(3).
+
+       PROCEDURE DIVISION USING Input-String, Pad-Length, Pad-Character, Padded-String.
+           MOVE FUNCTION LENGTH(Trim(Input-String)) TO Input-Length
+           COMPUTE Pad-Count = Pad-Length - Input-Length
+           MOVE SPACES TO Padded-String
+           PERFORM VARYING Index FROM 1 BY 1 UNTIL Index > Pad-Count
+               MOVE Pad-Character TO Padded-String(Index:1)
+           END-PERFORM
+           STRING Input-String DELIMITED BY SIZE INTO Padded-String WITH POINTER Index
+           GOBACK.

--- a/src/leftpad.cpy
+++ b/src/leftpad.cpy
@@ -1,0 +1,17 @@
+       01  Input-String      PIC X(100).
+       01  Padded-String     PIC X(100).
+       01  Pad-Character     PIC X.
+       01  Pad-Length        PIC 9(3).
+       01  Input-Length      PIC 9(3).
+       01  Pad-Count         PIC 9(3).
+       01  Index             PIC 9(3).
+
+       PROCEDURE DIVISION USING Input-String, Pad-Length, Pad-Character, Padded-String.
+           MOVE FUNCTION LENGTH(Trim(Input-String)) TO Input-Length
+           COMPUTE Pad-Count = Pad-Length - Input-Length
+           MOVE SPACES TO Padded-String
+           PERFORM VARYING Index FROM 1 BY 1 UNTIL Index > Pad-Count
+               MOVE Pad-Character TO Padded-String(Index:1)
+           END-PERFORM
+           STRING Input-String DELIMITED BY SIZE INTO Padded-String WITH POINTER Index
+           GOBACK.


### PR DESCRIPTION
Add COBOL LeftPad implementation and example usage.

* **Add LeftPad implementation**: Add `src/leftpad.cbl` containing the COBOL code for the LeftPad function.
* **Add LeftPad copybook**: Add `src/leftpad.cpy` containing the copybook for the LeftPad implementation.
* **Add example program**: Add `examples/example.cbl` demonstrating how to use the LeftPad library in a COBOL program.
* **Update README**: Add instructions on how to use the LeftPad implementation as a library in other COBOL applications, and how to compile and run the example program.

